### PR TITLE
Bail out of executeMarking on expired scans

### DIFF
--- a/DBM-Core/modules/Icons.lua
+++ b/DBM-Core/modules/Icons.lua
@@ -235,12 +235,16 @@ do
 	end
 
 	local function executeMarking(scanId, unitId)
+		if not iconVariables[scanId] then
+			--Scan already expired
+			return
+		end
 		local guid = UnitGUID(unitId)
 		local cid = DBM:GetCIDFromGUID(guid)
 		local isFriend = UnitIsFriend("player", unitId)
 		local isFiltered = false
 		local success = false
-		if iconVariables[scanId] and (not iconVariables[scanId].allowFriendly and isFriend) or (iconVariables[scanId].skipMarked and GetRaidTargetIndex(unitId)) then
+		if (not iconVariables[scanId].allowFriendly and isFriend) or (iconVariables[scanId].skipMarked and GetRaidTargetIndex(unitId)) then
 			isFiltered = true
 			DBM:Debug(unitId.." was skipped because it's a filtered mob. Friend Flag: "..(isFriend and "true" or "false"), 3)
 		end


### PR DESCRIPTION
```
1x DBM-Core\modules\Icons.lua:235: attempt to index field '?' (a nil value)
[string "@DBM-Core\modules\Icons.lua"]:235: in function <DBM-Core\modules\Icons.lua:229>
[string "@DBM-Core\modules\Icons.lua"]:379: in function <DBM-Core\modules\Icons.lua:346>
[string "=(tail call)"]: ?
[string "@DBM-SanctumOfDomination\RemnantofNerzhul.lua"]:423: in function `handler'
[string "@DBM-Core\DBM-Core-bd1acd4.lua"]:908: in function <DBM-Core\DBM-Core.lua:895>
[string "=(tail call)"]: ?
[string "@DBM-Core\DBM-Core-bd1acd4.lua"]:908: in function <DBM-Core\DBM-Core.lua:895>

Locals:
Skipped (In Encounter)
```

ScanForMobs calls executeMarking for all unitIds as an initial scan. If (all) the target(s) are found during this initial scan, the remaining executeMarking calls run for a scanId that has already been cleaned up.

First I thought this was just a broken nil check missing parenthesis around the guarded part, but actually the function would need a few more nil checks and end up not doing anything useful anyway. Might as well bail out instead.

Line numbers don't quite match because I was on the previous alpha - looks like the latest didn't go through on CurseForge.