### PR TITLE
Fix incorrect difficulty ID

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -5383,7 +5383,7 @@ function DBM:GetCurrentInstanceDifficulty()
 	local _, instanceType, difficulty, difficultyName, _, _, _, _, instanceGroupSize = GetInstanceInfo()
 	if difficulty == 0 or difficulty == 172 or (difficulty == 1 and instanceType == "none") or (C_Garrison and C_Garrison:IsOnGarrisonMap()) then--draenor field returns 1, causing world boss mod bug.
 		return "worldboss", RAID_INFO_WORLD_BOSS.." - ", difficulty, instanceGroupSize, 0
-	elseif difficulty == 1 or difficulty == 174 then--5 man Normal Dungeon
+	elseif difficulty == 1 or difficulty == 173 then--5 man Normal Dungeon
 		return "normal5", difficultyName.." - ", difficulty, instanceGroupSize, 0
 	elseif difficulty == 2 or difficulty == 174 then--5 man Heroic Dungeon
 		return "heroic5", difficultyName.." - ", difficulty, instanceGroupSize, 0


### PR DESCRIPTION
The alternative difficulty ID for normal in TBC Classic is 173. This
typo caused heroic dungeons with difficulty ID 174 to return "normal5"
for DBM use while showing "Heroic - " in the display texts. If 173 was
ever used in game it got "normal" and "" through the failsafe else
block.