### PR TITLE
Prevent pformat fallback from eating closing parenthesis

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -848,7 +848,7 @@ do
 
 	function pformat(fstr, ...)
 		local ok, str = pcall(format, fstr, ...)
-		return ok and str or fstr:gsub("(%%+)([^%%%s<]+)", replace):gsub("%%%%", "%%")
+		return ok and str or fstr:gsub("(%%+)([^%%%s%)<]+)", replace):gsub("%%%%", "%%")
 	end
 end
 


### PR DESCRIPTION
Many count warning, timer and yell texts wrap the count value in parentheses. If the count is not provided, format fails and pformat attempts to replace the format token with "Unknown". The current gsub pattern however was also capturing the closing parenthesis, showing the user messages with unbalanced parentheses.
![image](https://github.com/DeadlyBossMods/DBM-Unified/assets/16635602/31862328-9ac2-42d1-a540-6b108488aae9)
![image](https://github.com/DeadlyBossMods/DBM-Unified/assets/16635602/a25f87f3-2fdc-4fda-aecf-c6bc6d9ba8d3)