### PR TITLE
Correctly send chat on SAY channel when using :CountdownSay()

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -8833,7 +8833,7 @@ do
 			local _, _, _, _, _, expireTime = DBM:UnitDebuff("player", time)
 			if expireTime then
 				local remaining = expireTime-GetTime()
-				DBMScheduler:ScheduleCountdown(remaining, numAnnounces, self.Yell, self.mod, self, ...)
+				DBMScheduler:ScheduleCountdown(remaining, numAnnounces, self.Say, self.mod, self, ...)
 			end
 		else
 			DBMScheduler:ScheduleCountdown(time, numAnnounces, self.Say, self.mod, self, ...)


### PR DESCRIPTION
Magmorax mod expects the text to be white (https://github.com/DeadlyBossMods/DBM-Retail/blob/42a1066a6832bd12f6a8c5186d7a72cd87e6c82c/DBM-Aberrus/Magmorax.lua#L289), but: 
![image](https://github.com/DeadlyBossMods/DBM-Unified/assets/16635602/4ca219e6-5668-4a4a-b0ff-325860af1af9)

This has been incorrect since it was added during SL beta for Inerva mechanic that didn't make it to live (https://github.com/DeadlyBossMods/DBM-Retail/commit/01a0424f36ed1840af7eb916ee33ad52fedc5b01), and as far as I can tell was not used elsewhere until now.