### PR TITLE
Fix VPVersion and forceDisable handling in version sync

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -4169,12 +4169,16 @@ do
 		revision, version = tonumber(revision), tonumber(version)
 		if protocol >= 2 then
 			forceDisable = tonumber(forceDisable) or 0
+		else
+			-- Protocol 1 did not send forceDisable, VPVersion was in that position
+			VPVersion = forceDisable
+			forceDisable = 0
 		end
 		if revision and version and displayVersion and raid[sender] then
 			raid[sender].revision = revision
 			raid[sender].version = version
 			raid[sender].displayVersion = displayVersion
-			raid[sender].VPVersion = protocol == 2 and VPVersion or forceDisable--If protocol 1, there is no forceDisable arg
+			raid[sender].VPVersion = VPVersion
 			raid[sender].locale = locale
 			raid[sender].enabledIcons = iconEnabled or "false"
 			DBM:Debug("Received version info from "..sender.." : Rev - "..revision..", Ver - "..version..", Rev Diff - "..(revision - DBM.Revision), 3)


### PR DESCRIPTION
* If received VPVersion was nil, the and-or expression inserted forceDisable into the VPVersion field and showed that in version check.
![image](https://github.com/DeadlyBossMods/DBM-Unified/assets/16635602/db4eb170-c2d4-477d-a791-00c54acf94af)
![image](https://github.com/DeadlyBossMods/DBM-Unified/assets/16635602/a1b4c69e-612c-4581-b4bb-a2ece6546a73)

* Protocol v1 messages passed the sender's VPVersion as the forceDisable arg to HandleVersion. While harmless because forceDisable isn't checked unless version is also higher, better zero it out than pass incorrect values.