### PR TITLE
Fix private auras without voicepack + minor voicepack selection issues

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -9806,13 +9806,16 @@ do
 			local activeVP = self.Options.ChosenVoicePack2
 			--Check if voice pack out of date
 			if activeVP ~= "None" and activeVP == value then
-				if self.VoiceVersions[value] < minVoicePackVersion then--Version will be bumped when new voice packs released that contain new voices.
-					if self.Options.ShowReminders then
-						self:AddMsg(L.VOICE_PACK_OUTDATED)
+				-- User might reselect "missing" entry shown in GUI if previously selected voice pack is uninstalled or disabled
+				if self.VoiceVersions[value] then
+					if self.VoiceVersions[value] < minVoicePackVersion then--Version will be bumped when new voice packs released that contain new voices.
+						if self.Options.ShowReminders then
+							self:AddMsg(L.VOICE_PACK_OUTDATED)
+						end
+						SWFilterDisabled = self.VoiceVersions[value]--Set disable to version on current voice pack
+					else
+						SWFilterDisabled = minVoicePackVersion
 					end
-					SWFilterDisabled = self.VoiceVersions[value]--Set disable to version on current voice pack
-				else
-					SWFilterDisabled = minVoicePackVersion
 				end
 			end
 		end

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -10912,8 +10912,8 @@ function bossModPrototype:EnablePrivateAuraSound(auraspellId, voice, voiceVersio
 		if not self.paSounds then self.paSounds = {} end
 		local mediaPath
 		--Check valid voice pack sound
-		if (voiceVersion <= SWFilterDisabled) then
-			local chosenVoice = DBM.Options.ChosenVoicePack2
+		local chosenVoice = DBM.Options.ChosenVoicePack2
+		if chosenVoice ~= "None" and not voiceSessionDisabled and voiceVersion <= SWFilterDisabled then
 			mediaPath = "Interface\\AddOns\\DBM-VP"..chosenVoice.."\\"..voice..".ogg"
 		else
 			mediaPath = "Interface\\AddOns\\DBM-Core\\sounds\\AirHorn.ogg"

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -9808,6 +9808,7 @@ do
 			if activeVP ~= "None" and activeVP == value then
 				-- User might reselect "missing" entry shown in GUI if previously selected voice pack is uninstalled or disabled
 				if self.VoiceVersions[value] then
+					voiceSessionDisabled = false
 					if self.VoiceVersions[value] < minVoicePackVersion then--Version will be bumped when new voice packs released that contain new voices.
 						if self.Options.ShowReminders then
 							self:AddMsg(L.VOICE_PACK_OUTDATED)
@@ -9816,6 +9817,8 @@ do
 					else
 						SWFilterDisabled = minVoicePackVersion
 					end
+				else
+					voiceSessionDisabled = true
 				end
 			end
 		end


### PR DESCRIPTION
* Private auras sound didn't work without choosing a valid voicepack.
* If the chosen voice pack is deleted/disabled, GUI shows it as a special missing entry. Selecting it caused an error comparing nil to number.
* If the chosen voice pack is deleted/disabled, voice was disabled (`disableVoiceSession = true`) until reload. Restore/re-disable when updating voice pack choice.