### PR TITLE
Revert "Doesn't fix any bugs, but no reason for sender to be nil when…

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -11507,7 +11507,7 @@ function bossModPrototype:SendSync(event, ...)
 	--Mod syncs are more strict and enforce latency threshold always.
 	--Do not put latency check in main sendSync local function (line 313) though as we still want to get version information, etc from these users.
 	if not private.modSyncSpam[spamId] or (time - private.modSyncSpam[spamId]) > 8 then
-		self:ReceiveSync(event, playerName, self.revision or 0, tostringall(...))
+		self:ReceiveSync(event, nil, self.revision or 0, tostringall(...)) -- keep sender as nil, for (self.blockSyncs and sender) check
 		sendSync(DBMSyncProtocol, "M", str)
 	end
 end


### PR DESCRIPTION
… sending sync to self"

This reverts commit 0e74f7fbfc920ba2a6eb859fbb73eb287adef03d.

![image](https://github.com/DeadlyBossMods/DBM-Unified/assets/10605951/91562e45-aefb-4400-aac8-61f8ff345ecb)

ReceiveSync checks if sender is nil to determine if it is a sync from another player and block it with self.blockSyncs if out of combat after EndCombat runs once (on EndCombat it is defined as true)



https://github.com/DeadlyBossMods/DBM-Unified/blob/1b9bd0ccda45429226edf4fdc19912b82d9cbb06/DBM-Core/DBM-Core.lua#L5381