### PR TITLE
Revert another breaking change

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -10197,7 +10197,7 @@ do
 			--timer: Raw timer value (number).
 			--Icon: Texture Path for Icon
 			--type: Timer type (Cooldowns: cd, cdcount, nextcount, nextsource, cdspecial, nextspecial, stage, ai. Durations: target, active, fades, roleplay. Casting: cast)
-			--spellId: Raw spellid if available (most timers will have spellId or EJ ID unless it's a specific timer not tied to ability such as pull or combat start or rez timers. EJ id will be in format -%d (ie -1234 for journal section id 1234)
+			--spellId: Raw spellid if available (most timers will have spellId or EJ ID unless it's a specific timer not tied to ability such as pull or combat start or rez timers. EJ id will be in format ej%d
 			--colorID: Type classification (1-Add, 2-Aoe, 3-targeted ability, 4-Interrupt, 5-Role, 6-Stage, 7-User(custom))
 			--Mod ID: Encounter ID as string, or a generic string for mods that don't have encounter ID (such as trash, dummy/test mods)
 			--Keep: true or nil, whether or not to keep bar on screen when it expires (if true, timer should be retained until an actual TimerStop occurs or a new TimerStart with same barId happens (in which case you replace bar with new one)
@@ -10223,17 +10223,7 @@ do
 			if not guid and self.mod.sendMainBossGUID and not DBM.Options.DontSendBossGUIDs and (self.type == "cd" or self.type == "next" or self.type == "cdcount" or self.type == "nextcount" or self.type == "cdspecial" or self.type == "ai") then
 				guid = UnitGUID("boss1")
 			end
-			--TODO, actually change format of all mods and calls in core to just use the BW format since it's cleaner (ej ID as number, but negative)
-			--For now, we correct it for callback compat so that EJ Ids are in same format as BW
-			local adjustedSpellId
-			if type(self.spellId) == "string" and self.spellId:match("ej%d+") then
-				adjustedSpellId = string.sub(self.spellId, 3)
-				adjustedSpellId = tonumber(adjustedSpellId)
-				adjustedSpellId = -adjustedSpellId
-			else
-				adjustedSpellId = self.spellId
-			end
-			fireEvent("DBM_TimerStart", id, msg, timer, self.icon, self.type, adjustedSpellId, colorId, self.mod.id, self.keep, self.fade, self.name, guid, timerCount)
+			fireEvent("DBM_TimerStart", id, msg, timer, self.icon, self.type, self.spellId, colorId, self.mod.id, self.keep, self.fade, self.name, guid, timerCount)
 			--Bssically tops bar from starting if it's being put on a plater nameplate, to give plater users option to have nameplate CDs without actually using the bars
 			--This filter will only apply to trash mods though, boss timers will always be shown due to need to have them exist for Pause, Resume, Update, and GetTime/GetRemaining methods
 			if guid and DBM.Options.DontShowTimersWithNameplates and Plater and Plater.db.profile.bossmod_support_bars_enabled and self.mod.isTrashMod then


### PR DESCRIPTION
This change broke existing DBM timer WeakAuras that match `"ej12345"` style spell ID, if any such auras exist. My BW compat work doesn't need this as there's a generic ID mapping mechanism.

If we prefer `-12345` over `"ej12345"` in the future, core can be made to support both formats, and both DBM mods and WAs for future content can use the new format, so translating for callbacks is still unnecessary. If/when we want to drop old format entirely, it should probably be done after the next expansion has released to avoid affecting current content.