### PR TITLE
Fix shell script syntax in deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,10 @@ jobs:
 
       - name: Deploy on ${{ matrix.repo }}
         run: |
-          COMMIT_MESSAGE=$(cat <<EOF
+          COMMIT_MESSAGE=$(cat <<'EOF'
           ${{ github.event.head_commit.message }}
-          EOF)
+          EOF
+          )
           COMMIT_MESSAGE=$(echo $COMMIT_MESSAGE | sed 's/"/\\"/g')
           cd /home/runner/work/DBM-Unified/${{ matrix.repo }}
           git remote set-url origin "https://${{ secrets.PERSONAL_TOKEN }}@github.com/DeadlyBossMods/${{ matrix.repo }}.git"


### PR DESCRIPTION
* Quoting the heredoc delimiter prevents shell expansion of the content
* The delimiter followed by the closing parenthesis on the same line seems to work, but is incorrect syntax and generates a warning.