### PR TITLE
Fix range check compatibility mode when range finder frame is already visible

### DIFF
--- a/DBM-Core/DBM-RangeCheck.lua
+++ b/DBM-Core/DBM-RangeCheck.lua
@@ -895,10 +895,10 @@ function rangeCheck:Show(range, filter, forceshow, redCircleNumPlayers, reverse,
 		createRadarFrame()
 	end
 	local restrictionsActive = DBM:HasMapRestrictions()
+	if restrictionsActive then
+		range = setCompatibleRestrictedRange(range)
+	end
 	if (DBM.Options.RangeFrameFrames == "text" or DBM.Options.RangeFrameFrames == "both" or restrictionsActive) and not textFrame:IsShown() then
-		if restrictionsActive then
-			range = setCompatibleRestrictedRange(range)
-		end
 		textFrame:Show()
 	end
 	-- TODO, add check for restricted area here so we can prevent radar frame loading.


### PR DESCRIPTION
My guild is having issues in Wotlk Classic ICC Blood Prince Council with the range finder not showing players in range.

I believe this is due to the [BPCouncil Mod choosing 12y range](https://github.com/DeadlyBossMods/DBM-WotLK/blob/ffa9f233e3f0cf735aed06a79a9ecd88542e142e/DBM-Raids-WoTLK/Icecrown/TheCrimsonHall/BPCouncil.lua#L75), and that not being a valid range in a restricted area such as a raid.

I think it is caused by the check I modified in this PR. If someone has the frame visible at the start of the fight (with maybe 8 yards selected), then at the time the mod choses 12 yards for the range, the frame is already visible and the compatibility conversion is not being done. The conversion of the range should only depend on `restrictionsActive`, not on `not textFrame:IsShown()`, i. e. be moved before the _if_ statement in L898.

I have validated the behaviour and the fix in a 2-player party in Violet Hold, I assume it will work the same in the raid.