### PR TITLE
Add another nil check to NameplateIcon_Hide

### DIFF
--- a/DBM-Core/DBM-Nameplate.lua
+++ b/DBM-Core/DBM-Nameplate.lua
@@ -379,7 +379,7 @@ function NameplateIcon_Hide(isGUID, unit, index, force)
 	end
 
 	-- cleanup
-	if unit and (not index or #units[unit] == 0) then
+	if unit and units[unit] and (not index or #units[unit] == 0) then
 		units[unit] = nil
 		num_units = num_units - 1
 	end


### PR DESCRIPTION
Ran into this on Morchie when boss died while I had fixate on me. `OnCombatEnd` force-hides all icons which wipes the `units` table, but Core unregisters SPELL_AURA_REMOVED with a delay so the mod's S_A_R still executes, and `NameplateIcon_Hide` gets called again for the specific unit and does `#units[unit]` -> `#nil` to see if the per-unit table should be removed.

Nil checking `unit` separately is unnecessary as `someTable[nil]` is a valid lookup that always results in `nil`, but I left it in for clarity.