### PR TITLE
Fix wrong field

### DIFF
--- a/DBM-Core/DBM-Nameplate.lua
+++ b/DBM-Core/DBM-Nameplate.lua
@@ -126,8 +126,8 @@ do
 			elseif a_aura_tbl.auraType == 2 and b_aura_tbl.auraType == 2 then
 				local at, bt = a_aura_tbl.duration or 0, b_aura_tbl.duration or 0
 				local as, bs = a_aura_tbl.startTime or 0, b_aura_tbl.startTime or 0
-				local ar = at - (curTime - (a_aura_tbl.paused and (curTime - (a_aura_tbl.pauseStartTime - a_aura_tbl.start)) or as))
-				local br = bt - (curTime - (b_aura_tbl.paused and (curTime - (b_aura_tbl.pauseStartTime - b_aura_tbl.start)) or bs))
+				local ar = at - (curTime - (a_aura_tbl.paused and (curTime - (a_aura_tbl.pauseStartTime - as)) or as))
+				local br = bt - (curTime - (b_aura_tbl.paused and (curTime - (b_aura_tbl.pauseStartTime - bs)) or bs))
 				return br > ar
 			elseif (a_aura_tbl.startTime + a_aura_tbl.duration) < (b_aura_tbl.startTime + b_aura_tbl.duration) then
 				return true

--- a/DBM-Core/DBM-Nameplate.lua
+++ b/DBM-Core/DBM-Nameplate.lua
@@ -126,8 +126,8 @@ do
 			elseif a_aura_tbl.auraType == 2 and b_aura_tbl.auraType == 2 then
 				local at, bt = a_aura_tbl.duration or 0, b_aura_tbl.duration or 0
 				local as, bs = a_aura_tbl.startTime or 0, b_aura_tbl.startTime or 0
-				local ar = at - (curTime - (a_aura_tbl.paused and (curTime - (a_aura_tbl.pauseStartTime - as)) or as))
-				local br = bt - (curTime - (b_aura_tbl.paused and (curTime - (b_aura_tbl.pauseStartTime - bs)) or bs))
+				local ar = at - (a_aura_tbl.paused and (a_aura_tbl.pauseStartTime - as) or (curTime - as))
+				local br = bt - (b_aura_tbl.paused and (b_aura_tbl.pauseStartTime - bs) or (curTime - bs))
 				return br > ar
 			elseif (a_aura_tbl.startTime + a_aura_tbl.duration) < (b_aura_tbl.startTime + b_aura_tbl.duration) then
 				return true


### PR DESCRIPTION
`aura_tbl.start` is not assigned anywhere, it should be `.startTime` which is copied to local `as`/`bs` above. This caused error on Warlord Sargha, when boss nameplate went offscreen while multiple timers were paused.

Simplify expression to make it clearer what is actually being calculated: `remaining = total - elapsed`.