### PR TITLE
Improve berserk timer options

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -381,6 +381,7 @@ DBM.DefaultOptions = {
 	AlwaysShowSpeedKillTimer2 = false,
 	ShowRespawn = true,
 	ShowQueuePop = true,
+	ShowBerserkWarnings = true,
 	HelpMessageVersion = 3,
 	MoviesSeen = {},
 	MovieFilter2 = "Never",
@@ -11168,10 +11169,13 @@ do
 	local mt = {__index = enragePrototype}
 
 	function enragePrototype:Start(timer)
+		--User only has timer object exposed in mod options, check that here to also prevent the warnings.
+		if not self.owner.Options.timer_berserk then return end
 		timer = timer or self.timer or 600
 		timer = timer <= 0 and self.timer - mabs(timer) or timer
 		self.bar:SetTimer(timer)
 		self.bar:Start()
+		if not DBM.Options.ShowBerserkWarnings then return end
 		if self.warning1 then
 			if timer > 660 then self.warning1:Schedule(timer - 600, 10, L.MIN) end
 			if timer > 300 then self.warning1:Schedule(timer - 300, 5, L.MIN) end
@@ -11202,8 +11206,8 @@ do
 
 	function bossModPrototype:NewBerserkTimer(timer, text, barText, barIcon)
 		timer = timer or 600
-		local warning1 = self:NewAnnounce(text or L.GENERIC_WARNING_BERSERK, 1, nil, "warning_berserk", false)
-		local warning2 = self:NewAnnounce(text or L.GENERIC_WARNING_BERSERK, 4, nil, "warning_berserk", false)
+		local warning1 = self:NewAnnounce(text or L.GENERIC_WARNING_BERSERK, 1, nil, nil, false)
+		local warning2 = self:NewAnnounce(text or L.GENERIC_WARNING_BERSERK, 4, nil, nil, false)
 		--timer, name, icon, optionDefault, optionName, colorType, inlineIcon, keep, countdown, countdownMax, r, g, b, spellId, requiresCombat, waCustomName, customType
 		local bar = self:NewTimer(timer, barText or L.GENERIC_TIMER_BERSERK, barIcon or 28131, nil, "timer_berserk", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "berserk")
 		local obj = setmetatable(

--- a/DBM-Core/modules/objects/Localization.lua
+++ b/DBM-Core/modules/objects/Localization.lua
@@ -32,7 +32,6 @@ local defaultTimerLocalization = {
 
 local defaultAnnounceLocalization = {
 	__index = setmetatable({
-		warning_berserk = L.GENERIC_WARNING_BERSERK
 	}, returnKey)
 }
 

--- a/DBM-GUI/localization.en.lua
+++ b/DBM-GUI/localization.en.lua
@@ -107,6 +107,7 @@ L.TimerGeneral 						= "Timer Options"
 L.SKT_Enabled						= "Show record victory timer for current fight if available"
 L.ShowRespawn						= "Show boss respawn timer after a wipe"
 L.ShowQueuePop						= "Show time remaining to accept a queue pop (LFG,BG,etc)"
+L.ShowBerserkWarnings				= "Show announcements at 10/5/3/1 minutes and at 30/10 seconds remaining on $spell:26662 timer"
 --
 --Auto Logging: Logging toggles/types
 L.Area_AutoLogging					= "Auto Logging Toggles"

--- a/DBM-GUI/modules/options/general/ExtraFeatures.lua
+++ b/DBM-GUI/modules/options/general/ExtraFeatures.lua
@@ -14,6 +14,7 @@ local generaltimeroptions	= extraFeaturesPanel:CreateArea(L.TimerGeneral)
 generaltimeroptions:CreateCheckButton(L.SKT_Enabled, true, nil, "AlwaysShowSpeedKillTimer2")
 generaltimeroptions:CreateCheckButton(L.ShowRespawn, true, nil, "ShowRespawn")
 generaltimeroptions:CreateCheckButton(L.ShowQueuePop, true, nil, "ShowQueuePop")
+generaltimeroptions:CreateCheckButton(L.ShowBerserkWarnings, true, nil, "ShowBerserkWarnings")
 
 local bossLoggingArea		= extraFeaturesPanel:CreateArea(L.Area_AutoLogging)
 bossLoggingArea:CreateCheckButton(L.AutologBosses, true, nil, "AutologBosses")


### PR DESCRIPTION
* Mod-level toggle now also properly disables announces.
* Add a core toggle to disable announces while keeping the timer. The timer can still be useful even if the user doesn't like the announces and feels that they are annoying. Core option avoids adding more checkboxes (and the General Announces category if it wasn't otherwise used) to already crowded mod options.
* Remove a confusing parameter that did nothing.
* Remove unused default localization entry. The actual string is still used directly in `NewBerserkTimer`.