### PR TITLE
Add generic fallback for invalid spell/EJ/achievement ID in GUI

### DIFF
--- a/DBM-GUI/DBM-GUI.lua
+++ b/DBM-GUI/DBM-GUI.lua
@@ -420,22 +420,23 @@ function DBM_GUI:CreateBossModPanel(mod)
 				elseif tonumber(spellID) then
 					spellID = tonumber(spellID)
 					if spellID < 0 then
-					    title, desc, _, icon = DBM:EJ_GetSectionInfo(-spellID)
+						title, desc, _, icon = DBM:EJ_GetSectionInfo(-spellID)
 					else
 						local _title = DBM:GetSpellInfo(spellID)
 						if _title then
 							title, desc, icon = _title, tonumber(spellID), GetSpellTexture(spellID)
-						else--Not a valid spellid (Such as a ptr/beta mod loaded on live
-							title, desc, icon = spellID, L.NoDescription, 136116
 						end
 					end
 				elseif spellID:find("^ej") then
 					title, desc, _, icon = DBM:EJ_GetSectionInfo(spellID:gsub("ej", ""))
 				elseif spellID:find("^at") then
-					spellID = spellID:gsub("at", "")
-					_, title, _, _, _, _, _, desc, _, icon = GetAchievementInfo(spellID)
-				else
-					title = spellID
+					_, title, _, _, _, _, _, desc, _, icon = GetAchievementInfo(spellID:gsub("at", ""))
+					if not title then--Core has debug for spell and EJ, but this calls WoW API directly
+						DBM:Debug("|cffff0000Invalid call to GetAchievementInfo for achievementID: |r"..spellID:gsub("at", ""))
+					end
+				end
+				if not title then--Spell/EJ section/achievement not found - typo/removed/ptr or beta mod on live
+					title, desc, icon = spellID, L.NoDescription, 136116
 				end
 				if not usedSpellID then
 					usedSpellID = "|Hgarrmission:DBM:wacopy:"..spellID.."|h|cff69ccf0"..spellID.."|r|h"


### PR DESCRIPTION
As it was, only spell ID had proper fallback - invalid EJ ID caused errors when trying to open the panel for the boss in question and would not open it.

Added debug message for invalid achievement ID while at it.