### PR TITLE
 Add UI option to select chat frame for DBM messages v2

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -98,6 +98,7 @@ globals = {
 	"GUILD",
 	"GUILD_INTEREST_RP",
 	"HIDE",
+	"HIGHLIGHT_FONT_COLOR",
 	"LARGE",
 	"LOCK_FRAME",
 	"MAX_TALENT_TABS", -- Classic
@@ -253,6 +254,7 @@ globals = {
 	"EJ_GetInstanceInfo",
 	"EJ_GetCreatureInfo",
 	"EJ_SetDifficulty",
+	"EnumerateFrames",
 	"FlashClientIcon",
 	"FreeTimerTrackerTimer",
 	"GameTooltip",

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -6826,10 +6826,10 @@ end
 -----------------------
 --  Misc. Functions  --
 -----------------------
-function DBM:AddMsg(text, prefix, useSound)
+function DBM:AddMsg(text, prefix, useSound, allowHiddenChatFrame)
 	local tag = prefix or (self.localization and self.localization.general.name) or L.DBM
 	local frame = DBM.Options.ChatFrame and _G[tostring(DBM.Options.ChatFrame)] or DEFAULT_CHAT_FRAME
-	if not frame or not frame:IsShown() then
+	if not frame or not frame:IsShown() and not allowHiddenChatFrame then
 		frame = DEFAULT_CHAT_FRAME
 	end
 	if prefix ~= false then

--- a/DBM-GUI/localization.en.lua
+++ b/DBM-GUI/localization.en.lua
@@ -226,7 +226,14 @@ L.SpecialWarnHeader4				= "Type 4: Set options for HIGH priority run away specia
 L.SpecialWarnHeader5				= "Type 5: Set options for announcements with notes containing your player name"
 
 -- Panel: Generalwarnings
-L.Tab_GeneralMessages 				= "Chatframe Messages"
+L.Tab_GeneralMessages 				= "Chat Frame Messages"
+L.SelectChatFrameArea				= "Chat Frame Options"
+L.SelectChatFrameButton				= "Select chat frame"
+L.SelectChatFrameInfoIdle			= "Messages are shown in %s."
+L.SelectChatFrameDefaultName		= "the default chat frame"
+L.SelectChatFrameInfoDone			= "Messages will be shown in this chat frame."
+L.SelectChatFrameInfoSelect			= "Click on a chat frame to select it."
+L.SelectChatFrameInfoSelectNow		= "Click to select %s."
 L.CoreMessages						= "Core Message Options"
 L.ShowPizzaMessage 					= "Show timer broadcast messages in chat frame"
 L.ShowAllVersions	 				= "Show boss mod versions for all group members in chat frame when doing a version check. (If disabled, still does out of date/current summery)"

--- a/DBM-GUI/modules/options/alerts/ChatframeMessages.lua
+++ b/DBM-GUI/modules/options/alerts/ChatframeMessages.lua
@@ -3,6 +3,71 @@ local isRetail = WOW_PROJECT_ID == (WOW_PROJECT_MAINLINE or 1)
 local L = DBM_GUI_L
 local generalWarningPanel = DBM_GUI.Cat_Alerts:CreateNewPanel(L.Tab_GeneralMessages, "option")
 
+local selectChatFrameArea = generalWarningPanel:CreateArea(L.SelectChatFrameArea)
+local selectFrameButton = selectChatFrameArea:CreateButton(L.SelectChatFrameButton, 96, 22)
+selectFrameButton:SetPoint("LEFT", selectChatFrameArea.frame, "LEFT", 10, 0)
+local selectFrameInfo = selectChatFrameArea:CreateText(nil, nil, nil, nil, nil, 0)
+selectFrameInfo:SetPoint("LEFT", selectFrameButton, "RIGHT", 10, 0)
+
+local function findChatFrameUnderCursor()
+	local f = EnumerateFrames()
+	while f do
+		if not f:IsProtected() and not f:IsForbidden() then
+			if f:GetName() and f:GetName():match("^ChatFrame") and f:IsMouseOver() and f:IsVisible() then
+				local id = f:GetName():match("ChatFrame(%d+)")
+				id = tonumber(id)
+				if id and _G["ChatFrame" .. id] then
+					return "ChatFrame" .. id
+				end
+			end
+		end
+		f = EnumerateFrames(f)
+	end
+end
+local function updateChatInfoText()
+	selectFrameInfo:SetText(L.SelectChatFrameInfoIdle:format(
+		DBM.Options.ChatFrame == "DEFAULT_CHAT_FRAME" and L.SelectChatFrameDefaultName
+			or HIGHLIGHT_FONT_COLOR:WrapTextInColorCode(DBM.Options.ChatFrame)
+			or HIGHLIGHT_FONT_COLOR:WrapTextInColorCode(DBM_COMMON_L.Unknown)
+	))
+	selectFrameInfo:GetWidth() -- this somehow fixes a bug that the updated text sometimes doesn't show
+end
+updateChatInfoText()
+
+local selectingChatFrame = false
+selectFrameButton:SetScript("OnShow", updateChatInfoText)
+selectFrameButton:SetScript("OnHide", function() selectingChatFrame = false end)
+selectFrameButton:SetScript("OnClick", function() selectingChatFrame = true end)
+selectFrameButton:SetScript("OnEvent", function(self, event)
+	if selectingChatFrame and event == "GLOBAL_MOUSE_DOWN" then
+		local newFrame = findChatFrameUnderCursor()
+		if newFrame then
+			DBM.Options.ChatFrame = newFrame
+			DBM:AddMsg(L.SelectChatFrameInfoDone, nil, nil, true)
+			updateChatInfoText()
+			selectingChatFrame = false
+		end
+	end
+end)
+local lastText
+selectFrameButton:SetScript("OnUpdate", function()
+	if not selectingChatFrame then return end
+	local newFrame = findChatFrameUnderCursor()
+	local newText
+	if newFrame then
+		newText = L.SelectChatFrameInfoSelectNow:format(HIGHLIGHT_FONT_COLOR:WrapTextInColorCode(newFrame))
+	else
+		newText = L.SelectChatFrameInfoSelect
+	end
+	if newText ~= lastText then
+		lastText = newText
+		selectFrameInfo:SetText(newText)
+		selectFrameInfo:GetWidth() -- this somehow fixes a bug that the updated text sometimes doesn't show
+	end
+end)
+selectFrameButton:RegisterEvent("GLOBAL_MOUSE_DOWN")
+
+
 local generalCoreArea = generalWarningPanel:CreateArea(L.CoreMessages)
 generalCoreArea:CreateCheckButton(L.ShowPizzaMessage, true, nil, "ShowPizzaMessage")
 generalCoreArea:CreateCheckButton(L.ShowAllVersions, true, nil, "ShowAllVersions")


### PR DESCRIPTION
Like #349 but without the taint problems.

Also fixed the "this frame will be used" preview message if clicking on a background frame (via the tab header)