### PR TITLE
Change default for TDecimal from 11 to 9.9

### DIFF
--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -99,7 +99,7 @@ DBT.DefaultOptions = {
 	Sort = "Sort",
 	DesaturateValue = 1,
 	-- Huge bar
-	EnlargeBarTime = 11,
+	EnlargeBarTime = 9.9,
 	HugeBarXOffset = 0,
 	HugeBarYOffset = 0,
 	HugeWidth = 200,


### PR DESCRIPTION
This makes timers format as %.2f at 9.9, this avoids a large jump in the width of the text when going from 10 to 9.9 instead of going from 11 to 10.9