### PR TITLE
Add Gnomeregan level up raid (fixes auto-logging)

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -605,7 +605,10 @@ else--TBC and Vanilla
 	}
 	-- Season of Discovery
 	if C_Seasons and C_Seasons.GetActiveSeason() == 2 then
-		instanceDifficultyBylevel[48] = {25, 3} -- Blackfathom deeps level up raid
+		instanceDifficultyBylevel = {
+            [48] = {25, 3}, -- Blackfathom deeps level up raid
+            [90] = {40, 3}, -- Gnomeregan level up raid
+        }
 	end
 end
 


### PR DESCRIPTION
Verified in-game that auto-logging began after this change. Instance ID confirmed via GetInstanceInfo() in-game