### PR TITLE
Add simple boss health info frame

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -458,7 +458,7 @@ local usedProfile = "Default"
 local dbmIsEnabled = true
 private.dbmIsEnabled = dbmIsEnabled
 -- Table variables
-local newerVersionPerson, forceDisablePerson, cSyncSender, eeSyncSender, iconSetRevision, iconSetPerson, loadcIds, inCombat, oocBWComms, combatInfo, bossIds, raid, autoRespondSpam, queuedBattlefield, bossHealth, bossHealthuIdCache, lastBossEngage, lastBossDefeat = {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+local newerVersionPerson, forceDisablePerson, cSyncSender, eeSyncSender, iconSetRevision, iconSetPerson, loadcIds, inCombat, oocBWComms, combatInfo, bossIds, raid, autoRespondSpam, queuedBattlefield, bossHealth, bossNames, bossHealthuIdCache, lastBossEngage, lastBossDefeat = {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
 -- False variables
 local voiceSessionDisabled, targetEventsRegistered, combatInitialized, healthCombatInitialized, watchFrameRestore, questieWatchRestore, bossuIdFound, timerRequestInProgress = false, false, false, false, false, false, false, false
 -- Nil variables
@@ -5283,24 +5283,24 @@ function checkWipe(self, confirm)
 	end
 end
 
-function checkBossHealth(self, onlyHighest)
+function checkBossHealth(self, mod)
 	if #inCombat > 0 then
 		for _, v in ipairs(inCombat) do
 			if not v.multiMobPullDetection or v.mainBoss then
-				self:GetBossHP(v.mainBoss or v.combatInfo.mob or -1, onlyHighest)
+				self:GetBossHP(v.mainBoss or v.combatInfo.mob or -1, mod.onlyHighest)
 			else
 				for _, mob in ipairs(v.multiMobPullDetection) do
-					self:GetBossHP(mob, onlyHighest)
+					self:GetBossHP(mob, mod.onlyHighest)
 				end
 			end
 		end
-		self:Schedule(1, checkBossHealth, self, onlyHighest)
+		self:Schedule(mod.bossHealthUpdateTime or 1, checkBossHealth, self, mod)
 	end
 end
 
 function checkCustomBossHealth(self, mod)
 	mod:CustomHealthUpdate()
-	self:Schedule(1, checkCustomBossHealth, self, mod)
+	self:Schedule(mod.bossHealthUpdateTime or 1, checkCustomBossHealth, self, mod)
 end
 
 do
@@ -5458,9 +5458,9 @@ do
 				end
 				--boss health info scheduler
 				if mod.CustomHealthUpdate then
-					self:Schedule(1, checkCustomBossHealth, self, mod)
+					self:Schedule(mod.bossHealthUpdateTime or 1, checkCustomBossHealth, self, mod)
 				else
-					self:Schedule(1, checkBossHealth, self, mod.onlyHighest)
+					self:Schedule(mod.bossHealthUpdateTime or 1, checkBossHealth, self, mod)
 				end
 			end
 			--process global options
@@ -8546,6 +8546,7 @@ function DBM:GetBossHP(cIdOrGUID, onlyHighest)
 		if not onlyHighest or onlyHighest and hp > (bossHealth[cIdOrGUID] or 0) then
 			bossHealth[cIdOrGUID] = hp
 		end
+		bossNames[cIdOrGUID] = UnitName(uId)
 		return hp, uId, UnitName(uId)
 	--Focus, does not exist in classic
 	elseif isRetail and ((self:GetCIDFromGUID(UnitGUID("focus")) == cIdOrGUID or UnitGUID("focus") == cIdOrGUID) and UnitHealthMax("focus") ~= 0) then
@@ -8554,6 +8555,7 @@ function DBM:GetBossHP(cIdOrGUID, onlyHighest)
 		if not onlyHighest or onlyHighest and hp > (bossHealth[cIdOrGUID] or 0) then
 			bossHealth[cIdOrGUID] = hp
 		end
+		bossNames[cIdOrGUID] = UnitName("focus")
 		return hp, "focus", UnitName("focus")
 	else
 		--Boss UnitIds
@@ -8568,6 +8570,7 @@ function DBM:GetBossHP(cIdOrGUID, onlyHighest)
 						bossHealth[cIdOrGUID] = hp
 					end
 					bossHealthuIdCache[cIdOrGUID] = unitID
+					bossNames[cIdOrGUID] = UnitName(unitID)
 					return hp, unitID, UnitName(unitID)
 				end
 			end
@@ -8584,7 +8587,25 @@ function DBM:GetBossHP(cIdOrGUID, onlyHighest)
 					bossHealth[cIdOrGUID] = hp
 				end
 				bossHealthuIdCache[cIdOrGUID] = unitId
+				bossNames[cIdOrGUID] = UnitName(unitId)
 				return hp, unitId, UnitName(unitId)
+			end
+		end
+		if not isRetail then
+			--Scan a few nameplates if we don't have raid boss uIDs, but not worth trying all of them
+			for i = 1, 20 do
+				local unitId = "nameplate" .. i
+				local bossguid = UnitGUID(unitId)
+				if (self:GetCIDFromGUID(bossguid) == cIdOrGUID or bossguid == cIdOrGUID) and UnitHealthMax(unitId) ~= 0 then
+					if bossHealth[cIdOrGUID] and (UnitHealth(unitId) == 0 and not UnitIsDead(unitId)) then return bossHealth[cIdOrGUID], unitId, UnitName(unitId) end--Return last non 0 value if value is 0, since it's last valid value we had.
+					local hp = UnitHealth(unitId) / UnitHealthMax(unitId) * 100
+					if not onlyHighest or onlyHighest and hp > (bossHealth[cIdOrGUID] or 0) then
+						bossHealth[cIdOrGUID] = hp
+					end
+					bossHealthuIdCache[cIdOrGUID] = unitId
+					bossNames[cIdOrGUID] = UnitName(unitId)
+					return hp, unitId, UnitName(unitId)
+				end
 			end
 		end
 	end
@@ -8644,6 +8665,10 @@ function bossModPrototype:GetLowestBossHealth()
 end
 
 bossModPrototype.GetBossHP = DBM.GetBossHP
+
+function DBM:GetCachedBossHealth()
+	return bossHealth, bossNames
+end
 
 -------------------------
 --  Timers Table Util  --

--- a/DBM-Core/DBM-InfoFrame.lua
+++ b/DBM-Core/DBM-InfoFrame.lua
@@ -392,6 +392,27 @@ local function updateHealth()
 	updateIcons()
 end
 
+local bossHealthSortedLines = {}
+local function updateBossHealth()
+	twipe(lines)
+	twipe(bossHealthSortedLines)
+	local bossHealth, localizedBossNames = DBM:GetCachedBossHealth()
+	for cId, name in pairs(value[1]) do
+		if type(name) ~= "string" then
+			name = localizedBossNames[cId] or ("Boss " .. cId)
+		end
+		lines[name] = bossHealth[cId] or math.huge
+		bossHealthSortedLines[#bossHealthSortedLines + 1] = name
+	end
+	tsort(bossHealthSortedLines, function(e1, e2)
+		return lines[e1] > lines[e2]
+	end)
+	for name, hp in pairs(lines) do
+		lines[name] = hp < math.huge and (math.ceil(hp) .. "%") or DBM_COMMON_L.UNKNOWN
+	end
+	updateLines(bossHealthSortedLines)
+end
+
 local function updatePlayerPower()
 	twipe(lines)
 	local threshold = value[1]
@@ -906,6 +927,7 @@ end
 
 local events = {
 	["health"] = updateHealth,
+	["bosshealth"] = updateBossHealth,
 	["playerpower"] = updatePlayerPower,
 	["enemypower"] = updateEnemyPower,
 	["enemyabsorb"] = updateEnemyAbsorb,
@@ -968,7 +990,7 @@ local function onUpdate(frame, table)
 			error("DBM InfoFrame: leftText cannot be nil, Notify DBM author. Infoframe force shutting down ", 2)
 			frame:Hide()
 			return
-		elseif leftText and type(leftText) ~= "string" then
+		elseif type(leftText) ~= "string" then
 			leftText = tostring(leftText)
 		end
 		local rightText = lines[leftText]
@@ -1142,7 +1164,7 @@ function infoFrame:Show(modMaxLines, event, ...)
 	currentEvent = event
 	if event == "playerbuff" or event == "playerbaddebuff" or event == "playergooddebuff" then
 		sortMethod = 3 -- Sort by group ID
-	elseif event == "health" or event == "playerdebuffremaining" then
+	elseif event == "health" or event == "playerdebuffremaining" or event == "bosshealth" then
 		sortMethod = 2 -- Sort lowest first
 	elseif (event == "playerdebuffstacks" or event == "table") and value[2] and type(value[2]) == "number" then
 		sortMethod = value[2]


### PR DESCRIPTION
Displays the boss health that DBM keeps track of anyways. Can only be used for creature IDs that are explicitly registered for the mod