### PR TITLE
Core-BossTargetScanner: only filter active boss tank

### DIFF
--- a/DBM-Core/modules/TargetScanning.lua
+++ b/DBM-Core/modules/TargetScanning.lua
@@ -141,7 +141,7 @@ do
 		--Perform normal scan criteria matching
 		elseif targetname and targetuid and targetname ~= CL.UNKNOWN and (not targetFilter or (targetFilter and targetFilter ~= targetname)) then
 			if not IsInGroup() then scanTimes = 1 end--Solo, no reason to keep scanning, give faster warning. But only if first scan is actually a valid target, which is why i have this check HERE
-			if (isEnemyScan and UnitIsFriend("player", targetuid) or (onlyPlayers and not UnitIsUnit("player", targetuid)) or mod:IsTanking(targetuid, bossuid)) and not isFinalScan then--On player scan, ignore tanks. On enemy scan, ignore friendly player. On Only player, ignore npcs and pets
+			if (isEnemyScan and UnitIsFriend("player", targetuid) or (onlyPlayers and not UnitIsUnit("player", targetuid)) or mod:IsTanking(targetuid, bossuid, nil, true)) and not isFinalScan then--On player scan, ignore active tank. On enemy scan, ignore friendly player. On Only player, ignore npcs and pets
 				if targetScanCount[cidOrGuid] < scanTimes then--Make sure no infinite loop.
 					mod:ScheduleMethod(scanInterval, "BossTargetScanner", cidOrGuid, returnFunc, scanInterval, scanTimes, scanOnlyBoss, isEnemyScan, nil, targetFilter, tankFilter, onlyPlayers, filterFallback)--Scan multiple times to be sure it's not on something other then tank (or friend on enemy scan, or npc/pet on only person)
 				else--Go final scan.


### PR DESCRIPTION
1. TargetScanner currently excludes all tanks, and not just active `bossuid` tank
https://github.com/DeadlyBossMods/DBM-Unified/blob/master/DBM-Core/modules/TargetScanning.lua#L144C118-L144C152
Here we have the following check:
```lua
mod:IsTanking(targetuid, bossuid)
```
Which will detect all tank roles, as per 2.

2. IsTanking detects all tank roles if not onlyRequested
https://github.com/DeadlyBossMods/DBM-Unified/blob/master/DBM-Core/DBM-Core.lua#L8225

By doing a `onlyRequested` check during the initial scans, it will only detect active tank (and not by role, since previously `onlyRequested` was `nil`), thus picking up when Off-tank is the target (e.g.: ICC25H - Lich King with Shadow Trap). If target is indeed the active tank, the behaviour stays the same and it will default back to the full tank check on the last loop iteration.