### PR TITLE
Create LuaLS workflow

### DIFF
--- a/.github/workflows/luals.yml
+++ b/.github/workflows/luals.yml
@@ -1,0 +1,27 @@
+name: luals-checker
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+  pull_request:
+    branches:
+      - master
+
+run-name: LuaLS Check
+jobs:
+  LuaLS-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: ./workspace
+      - name: LuaLS check
+        uses: DeadlyBossMods/LuaLS-config@main
+        with:
+          luals-repo: emmericp/lua-language-server
+          luals-ref: 606e9cd238dbc924929d7047497de30ff44ee50c
+          luals-check-dir: ${{ github.workspace }}/workspace


### PR DESCRIPTION
Example of this in action: https://github.com/emmericp/test-gh-actions/pull/2/files#annotation_18742515697

This will not block a pull request or release, it just adds warnings as annotations to files. It will report success even if a warning was reported.

GitHub also only outputs at most 10 annotations unfortunately. But ideally this should never trigger because everyone uses VS Code with the plugin in https://github.com/DeadlyBossMods/LuaLS-Config/, right? ;)